### PR TITLE
LFS support + weights files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pth.tar filter=lfs diff=lfs merge=lfs -text

--- a/model_c_checkpoint_eot9.pth.tar
+++ b/model_c_checkpoint_eot9.pth.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cd19108d03d9a100349a8081a1bfdb02378f51f2ac6cb90a8b84e0a56a5348a
+size 72928346

--- a/model_d_checkpoint_eot9.pth.tar
+++ b/model_d_checkpoint_eot9.pth.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a4c5463c7fd049c9f3b9a3abd09b51c10a6153b49c833c0970b2b5ee2de4e9f
+size 440144784


### PR DESCRIPTION
Added weights files that can be loaded with the load_model function.

These weights were obtained after approximately one week of training on an azure machine with a standard GPU.